### PR TITLE
Switch to mysql-client

### DIFF
--- a/php/scripts/packages.sh
+++ b/php/scripts/packages.sh
@@ -28,7 +28,7 @@ export DEBIAN_FRONTEND=noninteractive
       gnupg2 \
       jq \
       libc-client-dev \
-      mariadb-client \
+      mysql-client \
       mongo-tools \
       openssh-client \
       python \


### PR DESCRIPTION
The MariaDB client is not compatible with default configurations of MySQL server 8.0, so any PHP app using this config will break. This PR switches to mysql-client, which is generally compatible with MariaDB server as well. Fixes #117